### PR TITLE
Add 5 newly created MONDO terms from #17

### DIFF
--- a/src/ontology/imports/merged_import.owl
+++ b/src/ontology/imports/merged_import.owl
@@ -7,8 +7,8 @@ Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
 
 
 Ontology(<https://w3id.org/nmdo/imports/merged_import.owl>
-<https://w3id.org/nmdo/releases/2026-07-08/imports/merged_import.owl>
-Annotation(owl:versionInfo "2026-07-08")
+<https://w3id.org/nmdo/releases/2026-07-09/imports/merged_import.owl>
+Annotation(owl:versionInfo "2026-07-09")
 
 Declaration(Class(<http://identifiers.org/hgnc/1020>))
 Declaration(Class(<http://identifiers.org/hgnc/10379>))
@@ -3539,6 +3539,11 @@ Declaration(Class(<http://purl.obolibrary.org/obo/MONDO_1040012>))
 Declaration(Class(<http://purl.obolibrary.org/obo/MONDO_1040021>))
 Declaration(Class(<http://purl.obolibrary.org/obo/MONDO_1040031>))
 Declaration(Class(<http://purl.obolibrary.org/obo/MONDO_1040033>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MONDO_1060001>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MONDO_1060002>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MONDO_1060003>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MONDO_1060004>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MONDO_1060006>))
 Declaration(Class(<http://purl.obolibrary.org/obo/MONDO_1060107>))
 Declaration(Class(<http://purl.obolibrary.org/obo/MONDO_1060109>))
 Declaration(Class(<http://purl.obolibrary.org/obo/MONDO_1060116>))
@@ -22800,7 +22805,7 @@ AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.ob
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/HP_0430071> "Abnormal circulating organic compound concentration")
 SubClassOf(<http://purl.obolibrary.org/obo/HP_0430071> <http://purl.obolibrary.org/obo/HP_0032180>)
 
-# Class: <http://purl.obolibrary.org/obo/IAO_0000027> (data item)
+# Class: <http://purl.obolibrary.org/obo/IAO_0000027> (data entity)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000111> <http://purl.obolibrary.org/obo/IAO_0000027> "data entity"@en)
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000111> <http://purl.obolibrary.org/obo/IAO_0000027> "data item"@en)
@@ -89912,6 +89917,54 @@ AnnotationAssertion(<http://www.w3.org/2004/02/skos/core#exactMatch> <http://pur
 AnnotationAssertion(<http://www.w3.org/2004/02/skos/core#exactMatch> <http://purl.obolibrary.org/obo/MONDO_1040033> <http://linkedlifedata.com/resource/umls/id/C5190847>)
 AnnotationAssertion(<http://www.w3.org/2004/02/skos/core#exactMatch> <http://purl.obolibrary.org/obo/MONDO_1040033> <http://www.orpha.net/ORDO/Orphanet_370980>)
 SubClassOf(Annotation(<http://www.geneontology.org/formats/oboInOwl#source> "https://orcid.org/0000-0002-0587-4693") <http://purl.obolibrary.org/obo/MONDO_1040033> <http://purl.obolibrary.org/obo/MONDO_0019950>)
+
+# Class: <http://purl.obolibrary.org/obo/MONDO_1060001> (AChR+ myasthenia gravis)
+
+AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "PMID:40651620") Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "https://orcid.org/0000-0002-1532-8725") <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/MONDO_1060001> "Myasthenia gravis characterized by the presence of autoantibodies against the muscle nicotinic acetylcholine receptor (AChR) in the serum, which damage the postsynaptic neuromuscular junction and cause skeletal muscle weakness and fatigue.")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/MONDO_1060001> "MONDO:1060001")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/MONDO_1060001> "AChR+ myasthenia gravis")
+SubClassOf(Annotation(<http://www.geneontology.org/formats/oboInOwl#source> "PMID:40651620") <http://purl.obolibrary.org/obo/MONDO_1060001> <http://purl.obolibrary.org/obo/MONDO_0009688>)
+
+# Class: <http://purl.obolibrary.org/obo/MONDO_1060002> (ocular myasthenia gravis)
+
+AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "PMID:36778719") Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "https://orcid.org/0000-0002-1532-8725") <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/MONDO_1060002> "Myasthenia gravis in which the muscles around the eyes are affected, that typically presents with ptosis and/or diplopia due to ophthalmoplegia")
+AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#source> "MONDO:equivalentTo") <http://www.geneontology.org/formats/oboInOwl#hasDbXref> <http://purl.obolibrary.org/obo/MONDO_1060002> "SCTID:230684008")
+AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "SCTID:230684008") Annotation(<http://www.geneontology.org/formats/oboInOwl#hasSynonymType> <http://purl.obolibrary.org/obo/mondo#ABBREVIATION>) <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/MONDO_1060002> "OMG")
+AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "SCTID:230684008") <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/MONDO_1060002> "ocular myasthenia")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/MONDO_1060002> "MONDO:1060002")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/MONDO_1060002> "ocular myasthenia gravis")
+AnnotationAssertion(<http://www.w3.org/2004/02/skos/core#exactMatch> <http://purl.obolibrary.org/obo/MONDO_1060002> <http://identifiers.org/snomedct/230684008>)
+SubClassOf(Annotation(<http://www.geneontology.org/formats/oboInOwl#source> "PMID:36778719") <http://purl.obolibrary.org/obo/MONDO_1060002> <http://purl.obolibrary.org/obo/MONDO_0009688>)
+
+# Class: <http://purl.obolibrary.org/obo/MONDO_1060003> (muscle-specific tyrosine kinase-associated myasthenia gravis)
+
+AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "doi:10.1016/j.jns.2025.123449") Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "https://orcid.org/0000-0002-1532-8725") <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/MONDO_1060003> "Myasthenia gravis characterized by the presence of autoantibodies against muscle-specific tyrosine kinase (MuSK) in the serum")
+AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#source> "MONDO:equivalentTo") <http://www.geneontology.org/formats/oboInOwl#hasDbXref> <http://purl.obolibrary.org/obo/MONDO_1060003> "SCTID:521000146105")
+AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "SCTID:521000146105") <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/MONDO_1060003> "MuSK+ myasthenia gravis")
+AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "SCTID:521000146105") <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/MONDO_1060003> "myasthenia gravis caused by muscle-specific tyrosine kinase antibodies")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/MONDO_1060003> "MONDO:1060003")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/MONDO_1060003> "muscle-specific tyrosine kinase-associated myasthenia gravis")
+AnnotationAssertion(<http://www.w3.org/2004/02/skos/core#exactMatch> <http://purl.obolibrary.org/obo/MONDO_1060003> <http://identifiers.org/snomedct/521000146105>)
+SubClassOf(Annotation(<http://www.geneontology.org/formats/oboInOwl#source> "doi:10.1016/j.jns.2025.123449") <http://purl.obolibrary.org/obo/MONDO_1060003> <http://purl.obolibrary.org/obo/MONDO_0009688>)
+
+# Class: <http://purl.obolibrary.org/obo/MONDO_1060004> (seronegative myasthenia gravis)
+
+AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "PMID:37759888") Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "https://orcid.org/0000-0002-1532-8725") <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/MONDO_1060004> "Myasthenia gravis characterized by the absence of detectable pathogenic auto-antibodies against acetylcholine receptor (AChR), muscle-specific tyrosine kinases (MuSK), and/or low-density lipoprotein receptor-related protein 4 (LRP4) in the sera.")
+AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "PMID:37759888") Annotation(<http://www.geneontology.org/formats/oboInOwl#hasSynonymType> <http://purl.obolibrary.org/obo/mondo#ABBREVIATION>) <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/MONDO_1060004> "SnMG")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/MONDO_1060004> "MONDO:1060004")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/MONDO_1060004> "seronegative myasthenia gravis")
+SubClassOf(Annotation(<http://www.geneontology.org/formats/oboInOwl#source> "PMID:37759888") <http://purl.obolibrary.org/obo/MONDO_1060004> <http://purl.obolibrary.org/obo/MONDO_0009688>)
+
+# Class: <http://purl.obolibrary.org/obo/MONDO_1060006> (generalized myasthenia gravis)
+
+AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "PMID:38117543") Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "https://orcid.org/0000-0002-1532-8725") <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/MONDO_1060006> "Myasthenia gravis in which muscle weakness affects one or more skeletal muscle groups outside the extraocular muscles")
+AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#source> "MONDO:equivalentTo") <http://www.geneontology.org/formats/oboInOwl#hasDbXref> <http://purl.obolibrary.org/obo/MONDO_1060006> "SCTID:230686005")
+AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "SCTID:230686005") Annotation(<http://www.geneontology.org/formats/oboInOwl#hasSynonymType> <http://purl.obolibrary.org/obo/mondo#ABBREVIATION>) <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/MONDO_1060006> "gMG")
+AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "SCTID:230686005") <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/MONDO_1060006> "generalized myasthenia")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/MONDO_1060006> "MONDO:1060006")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/MONDO_1060006> "generalized myasthenia gravis")
+AnnotationAssertion(<http://www.w3.org/2004/02/skos/core#exactMatch> <http://purl.obolibrary.org/obo/MONDO_1060006> <http://identifiers.org/snomedct/230686005>)
+SubClassOf(Annotation(<http://www.geneontology.org/formats/oboInOwl#source> "PMID:38117543") <http://purl.obolibrary.org/obo/MONDO_1060006> <http://purl.obolibrary.org/obo/MONDO_0009688>)
 
 # Class: <http://purl.obolibrary.org/obo/MONDO_1060107> (CYP7B1-related disorder of oxysterol accumulation)
 

--- a/src/ontology/imports/mondo_terms.txt
+++ b/src/ontology/imports/mondo_terms.txt
@@ -976,3 +976,8 @@ MONDO:0012747  # glycogen storage disease due to aldolase A deficiency
 MONDO:0009709  # myopathy, centronuclear, 2
 MONDO:0014418  # myopathy, centronuclear, 5
 MONDO:0009725  # nemaline myopathy 2
+MONDO:1060001  # AChR+ myasthenia gravis
+MONDO:1060002  # ocular myasthenia gravis
+MONDO:1060003  # muscle-specific tyrosine kinase-associated myasthenia gravis
+MONDO:1060004  # seronegative myasthenia gravis
+MONDO:1060006  # generalized myasthenia gravis


### PR DESCRIPTION
Added 5 new myasthenia gravis subclasses:

- `MONDO:1060001`     # AChR+ myasthenia gravis
- `MONDO:1060002`     # ocular myasthenia gravis
- `MONDO:1060003`     # muscle-specific tyrosine kinase-associated myasthenia gravis
- `MONDO:1060004`     # seronegative myasthenia gravis
- `MONDO:1060006`     # generalized myasthenia gravis

Closes #17 